### PR TITLE
Change Project name to uppercase

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let one = Version(1,0,0, prereleaseIdentifiers: ["beta"])
 let two = Version(2,0,0, prereleaseIdentifiers: ["beta"])
 
 let package = Package(
-    name: "migrator",
+    name: "Migrator",
     dependencies: [
         .Package(url: "https://github.com/vapor/fluent-provider.git", one),
         .Package(url: "https://github.com/vapor/leaf-provider.git", one)


### PR DESCRIPTION
In this way I can import the framework by doing 👍
```diff
- import migrator
+ import Migrator
```